### PR TITLE
Fix unescaped user messages

### DIFF
--- a/index.php
+++ b/index.php
@@ -471,8 +471,9 @@ define('BASE_URL', $protocol . $host . $scriptDir);
 
         $("#send").on("click", function() {
             var userMessage = $("#messages").val();
+            var safeMessage = $('<div>').text(userMessage).html();
             $("#messagedisplaysection").append(
-                `<div class="chat usermessages"><div class="user-avatar"></div>${userMessage}</div>`
+                `<div class="chat usermessages"><div class="user-avatar"></div>${safeMessage}</div>`
             ).scrollTop($("#messagedisplaysection")[0].scrollHeight);
 
             $.post("bot.php", {


### PR DESCRIPTION
## Summary
- prevent HTML injection by escaping user messages before appending to DOM

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840d4970b6c8326a4fbd3166625ba65